### PR TITLE
Restore: Support spaces in file/diagram names

### DIFF
--- a/restore-diagrams.bat
+++ b/restore-diagrams.bat
@@ -8,4 +8,4 @@ Setlocal EnableExtensions
 if "!server!"==""   set server=.
 if "!database!"=="" set database=ExampleDb
 
-for /f %%a IN ('dir /b /s *.sql') do call sqlcmd -S %server% -d %database%  -i %%a
+for /f "delims=" %%a IN ('dir /b /s *.sql') do call sqlcmd -S %server% -d %database%  -i %%~sdpnxa


### PR DESCRIPTION
Fixed bug in restoring diagrams: When a diagram has spaces in its name, then corresponding file gets ignored as the name in %%a becaomes incorrect.
