### PR TITLE
Backup: Remove prerequisites at the end

### DIFF
--- a/lib/ScriptDBDiagrams.ps1
+++ b/lib/ScriptDBDiagrams.ps1
@@ -35,7 +35,12 @@ while ($dr.Read()) {
 	$line | out-file $f -encoding ASCII
 	"Scripted '"+$name+"' to " +$f
 }
-"Diagrams retrieved. Closing connections..."
 $dr.Close()
+
+"Diagrams retrieved. Cleaning prerequisites..."
+$cmd.CommandText = [IO.File]::ReadAllText("lib\1-cleanup.sql")
+$result = $cmd.ExecuteNonQuery()
+
+"Closing connections..."
 $conn.Close()
 "Done."


### PR DESCRIPTION
Once all diagram files have been created, remove prerequisites (functions and stored procedures we created)
